### PR TITLE
User Engine Addition Support (Extensions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dist
 
 dist/
 secrets.json
+scripts/*.js

--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@ module.exports = {
 	version: '0.1b',
 	name: 'diddle.js/loader',
 	requires: [
-		'diddle.js/engine@0.1b'
+		'diddle.js/engine@0.5b'
 	]
 }
 
@@ -102,4 +102,4 @@ CustomConfigData.scripts_directory = path.join(path.resolve(CustomConfigData.scr
 
 var DoDebug = LaunchParameters.debug || LaunchParameters.developer || CustomConfigData.developer || CustomConfigData.debug || false;
 
-const diddleInstance = new (require("."))(CustomConfigData, DoDebug);
+const diddleInstance = new (require(".")).engine(CustomConfigData, DoDebug);

--- a/engine/diddle.config.default.json
+++ b/engine/diddle.config.default.json
@@ -6,6 +6,7 @@
 		"prefix": "!"
 	},
 	"locale": "en_US",
-	"scripts_directory": "./scripts/",
+	"scripts": "./scripts/",
+	"extensions": "./exts/",
 	"debug": false
 }

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -4,7 +4,7 @@ const LocaleManager = require("./locale.js");
 const ConfigurationManager = require("./configman.js");
 const EventManager = require("./eventman");
 const DiscordWrapper = require("./discord");
-const EngineExtensionManager = require("./extensions.js");
+const EngineExtensionManager = require("./extensionmanager.js");
 /**
  * @projectname diddle.js
  * @version 0.4b
@@ -80,9 +80,9 @@ class DiddleEngine {
 		this.ext = new EngineExtensionManager(diddle);
 
 		this.config._ready();
+		this.ext._ready();
 		this.scripts._ready();
 		this.discord._ready();
-		this.ext._ready();
 	}
 	/**
 	 * @constructor

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -20,7 +20,7 @@ class DiddleEngine {
 	 * @type {EngineScript.manifest}
 	 */
 	manifest = {
-		version: '0.4b',
+		version: '0.5b',
 		name: 'diddle.js/engine',
 		requires: [
 			'diddle.js/loader@0.1b',

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -4,6 +4,7 @@ const LocaleManager = require("./locale.js");
 const ConfigurationManager = require("./configman.js");
 const EventManager = require("./eventman");
 const DiscordWrapper = require("./discord");
+const EngineExtensionManager = require("./extensions.js");
 /**
  * @projectname diddle.js
  * @version 0.4b
@@ -27,7 +28,8 @@ class DiddleEngine {
 			'diddle.js/configman@0.1b',
 			'diddle.js/locale@0.1b',
 			'diddle.js/eventman@0.1b',
-			'diddle.js/discord@0.1b'
+			'diddle.js/discord@0.1b',
+			'diddle.js/extman@0.1b'
 		]
 	}
 
@@ -75,10 +77,12 @@ class DiddleEngine {
 		this.config = new ConfigurationManager(diddle,this._config);
 		this.discord = new DiscordWrapper(diddle);
 		this.scripts = new ScriptManager(diddle);
+		this.ext = new EngineExtensionManager(diddle);
 
 		this.config._ready();
 		this.scripts._ready();
 		this.discord._ready();
+		this.ext._ready();
 	}
 	/**
 	 * @constructor
@@ -100,6 +104,17 @@ class DiddleEngine {
 
 		this._wrapperPopulate();
 	}
-		
 }
-module.exports = DiddleEngine;
+
+module.exports = {
+	engine: DiddleEngine,
+	ScriptManager: require("./scriptman.js"),
+	Logger: require("./logger"),
+	LocaleManager: require("./locale"),
+	Configuration: require("./configman"),
+	EventManager: require("./eventman"),
+	EngineScript: require("./enginescript"),
+	Discord: require("./discord"),
+	ExtensionManager: require("./extensionmanager"),
+	Extension: require("./extensionscript")
+}

--- a/engine/extensionmanager.js
+++ b/engine/extensionmanager.js
@@ -1,0 +1,58 @@
+const EngineScript = require("./enginescript.js");
+const ExtensionScript = require("./extensionscript.js");
+
+const manifest = {
+	name: "diddle.js/extman",
+	version: "0.1b"
+}
+
+/**
+ * @class
+ * @property {string} cwd The absolute directory where all of the custom Engine Extensions live.
+ * @extends {EngineScript}
+ */
+class EngineExtensionManager extends EngineScript {
+	/**
+	 * @param {DiddleEngine} diddle 
+	 */
+	constructor(diddle) {
+		super(diddle,manifest);
+		// Current Working Directory
+		this.cwd = '';
+	}
+
+	_store = {
+		/*
+		<ScriptUID>: ExtensionScript
+		*/
+	}
+
+	/**
+	 * @description Add Custom Engine Extension
+	 * @param {ExtensionScript} extension 
+	 */
+	append(extension) {
+		this._store[extension._ScriptUID] = extension;
+	}
+
+	/**
+	 * @description Fetch Extension by its Unique Identifier
+	 * @param {string} extension 
+	 * @returns {ExtensionScript}
+	 */
+	getByUID(ScriptUID) {
+		if (this._store[ScriptUID] == undefined) throw new Error(this.diddle.locale.get("ScriptExt.FetchFail.ExtensionNotFound"))
+
+		return this._store[ScriptUID];
+	}
+
+	/**
+	 * @description Returns an Array of all Extensions that match the given name.
+	 * @param {*} ScriptName 
+	 * @returns {ExtensionScript[]}
+	 */
+	getByName(ScriptName) {
+		return this._score.filter(script => script.manifest.name == ScriptName);
+	}
+}
+module.exports = EngineExtensionManager;

--- a/engine/extensionmanager.js
+++ b/engine/extensionmanager.js
@@ -1,9 +1,15 @@
 const EngineScript = require("./enginescript.js");
 const ExtensionScript = require("./extensionscript.js");
+const path = require("path")
+const fs = require("fs")
 
 const manifest = {
 	name: "diddle.js/extman",
 	version: "0.1b"
+}
+
+function isClass(v) {
+	return typeof v === 'function' && /^\s*class\s+/.test(v.toString());
 }
 
 /**
@@ -19,6 +25,10 @@ class EngineExtensionManager extends EngineScript {
 		super(diddle,manifest);
 		// Current Working Directory
 		this.cwd = '';
+	}
+
+	_ready() {
+		this._fetchExtensions();
 	}
 
 	_store = {
@@ -42,7 +52,6 @@ class EngineExtensionManager extends EngineScript {
 	 */
 	getByUID(ScriptUID) {
 		if (this._store[ScriptUID] == undefined) throw new Error(this.diddle.locale.get("ScriptExt.FetchFail.ExtensionNotFound"))
-
 		return this._store[ScriptUID];
 	}
 
@@ -53,6 +62,53 @@ class EngineExtensionManager extends EngineScript {
 	 */
 	getByName(ScriptName) {
 		return this._score.filter(script => script.manifest.name == ScriptName);
+	}
+
+	_fetchExtensions() {
+		var config = this.diddle.config.get();
+
+		var timestamp_start = Date.now();
+
+		this.log.info(`fetching extensions...`);
+
+		this.cwd = path.resolve(config.extensions);
+
+		if (!fs.existsSync(this.cwd)) {
+			try {
+				fs.mkdirSync(this.cwd)
+			} catch(e) {
+				this.log.error(`cannot create extensions directory\n`,e);
+				process.exit(1);
+			}
+			this.log.info(`created extensions directory`);
+		}
+
+		
+		// Get Script Files
+		var ext_filenames,ext_filtered = [];
+
+		try {
+			ext_filenames = fs.readdirSync(this.cwd).filter(f => f.endsWith(".js"));
+		} catch(e) {
+			this.log.error(`cannot fetch extensions directory\n`,e);
+			process.exit(1);
+		}
+
+		for (let i = 0; i < ext_filenames.length; i++) {
+			let current_filename = ext_filenames[i];
+			let current = require(path.join(this.cwd,current_filename));
+
+			if (isClass(current)) {
+				var ext = new current(this.diddle)
+				ext_filtered.push(ext);
+				this.log.debug(`loaded extension ${ext.manifest.name}@${ext.manifest.version} (${ext._ScriptUID})`)
+			} else {
+				this.log.error(`extension '${path.join(this.cwd,current_filename)}' cannot be constructed (isn't a class)`);
+				return;
+			}
+		}
+
+		this.log.info(`took ${Date.now() - timestamp_start}ms`);
 	}
 }
 module.exports = EngineExtensionManager;

--- a/engine/extensionscript.js
+++ b/engine/extensionscript.js
@@ -1,4 +1,4 @@
-const diddle = require("./engine")
+const EngineScript = require("./enginescript")
 const crypto = require("crypto")
 
 /**
@@ -6,9 +6,8 @@ const crypto = require("crypto")
  * @property {string} _ScriptUID MD5 Sum of the Extensions Manifest Name and Version seperated by <code>@</code>
  * @extends {EngineScript}
  */
-class ExtensionScript extends diddle.EngineScript {
+class ExtensionScript extends EngineScript {
 	/**
-	 * 
 	 * @param {DiddleEngine} diddle 
 	 * @param {EngineScript.manifest} manifest 
 	 */

--- a/engine/extensionscript.js
+++ b/engine/extensionscript.js
@@ -1,0 +1,22 @@
+const diddle = require("./engine")
+const crypto = require("crypto")
+
+/**
+ * @class
+ * @property {string} _ScriptUID MD5 Sum of the Extensions Manifest Name and Version seperated by <code>@</code>
+ * @extends {EngineScript}
+ */
+class ExtensionScript extends diddle.EngineScript {
+	/**
+	 * 
+	 * @param {DiddleEngine} diddle 
+	 * @param {EngineScript.manifest} manifest 
+	 */
+	constructor(diddle,manifest) {
+		super(diddle,manifest);
+		this._ScriptUID = crypto.createHash("md5").update(manifest.name + "@" + manifest.version).digest("hex");
+		this.diddle.ext.append(this);
+	}
+
+}
+module.exports = ExtensionScript;

--- a/engine/scriptman.js
+++ b/engine/scriptman.js
@@ -23,7 +23,7 @@ class ScriptManager extends EngineScript{
 
 		this.log.info(`fetching scripts...`);
 
-		var scriptsdirectory = config.scripts_directory;
+		var scriptsdirectory = path.resolve(config.scripts);
 
 		if (!fs.existsSync(scriptsdirectory)) {
 			try {
@@ -57,9 +57,10 @@ class ScriptManager extends EngineScript{
 		}
 		for ( let j = 0; j < scripts_filenames.length; j++ ) {
 			try {
-				let currentscript = require(`${scriptsdirectory}${scripts_filenames[j]}`);
-
+				let scriptlocation = path.join(path.resolve(config.scripts),scripts_filenames[j])
 				let currentscript_fname = scripts_filenames[j];
+				let currentscript = require(scriptlocation);
+
 
 				var ValidScript = { };
 
@@ -180,8 +181,8 @@ class ScriptManager extends EngineScript{
 
 		for (let i = 0; i < scriptEvents.length; i++) {
 			let event = scriptEvents[i];
-			if (event[0] == 'onload') {
-				this.diddle.event.on('scripts-onload',event[1]);
+			if (event[0] == 'ready') {
+				this.diddle.event.on('scripts-ready',event[1]);
 			} else {
 				this.diddle.event.on(event[0],event[1]);
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {


### PR DESCRIPTION
# This update requires users to update their config

## Change the object name `scripts_directory` to `scripts` in your `diddle.config.json`

Added Support for User Engine Additions.

See `examples/` for some examples

### Example

ext/testExtension.js
```javascript
const diddle = require("diddle.js")

const manifest = {
	name: "MyExtensionName",
	version: "0.1b"
}

class TestExtension extends diddle.Extension {
	
	constructor(diddle) {
		super(diddle,manifest);
	}
}

module.exports = TestExtension;
```

scripts/example.js
```javascript
module.exports = {
	manifest: {
		author: "Jyles Coad-Ward",
		license: "MIT",
		type: "event",
	},
	event: {}
}
module.exports.event.ready = (diddle) => {
	console.log(diddle.ext.getByUID("44b9174cc7c7743b2e2bfdf1bc7ac03f").manifest)
}
```

Prints out the manifest for the TestExtension