### PR TITLE
0.1.5 - Token Manager

### DIFF
--- a/engine/configman.js
+++ b/engine/configman.js
@@ -22,10 +22,10 @@ const manifest = {
  * @property {LocaleManager.LocaleCode} locale
  * @property {string} scripts_directory
  * @property {bool} debug
+ * @property {object} token Has children with the object name of the service and the content of either a string, or an array of strings.
  */
 /**
  * @typedef ConfigurationManager.discordconfig
- * @property {string} token Discord Bot Token, If It's a User Token discord.js will reject it
  * @property {string[]} admin Discord User ID Snowflakes
  * @property {string} prefix Command Prefix
  */

--- a/engine/diddle.config.default.json
+++ b/engine/diddle.config.default.json
@@ -1,9 +1,11 @@
 {
 	"disable": false,
 	"discord": {
-		"token": "",
 		"admin": [],
 		"prefix": "!"
+	},
+	"token": {
+		"discord": ""
 	},
 	"locale": "en_US",
 	"scripts": "./scripts/",

--- a/engine/discord.js
+++ b/engine/discord.js
@@ -21,8 +21,9 @@ class DiscordWrapper extends EngineScript{
 	 */
 	async _ready() {
 		this.log.info("connecting to discord");
+		var token = this.diddle.token.get("discord");
 		try {
-			await this.client.login(this.diddle.config.get().discord.token);
+			await this.client.login(token);
 		} catch(e) {
 			this.log.error("failed to connect to discord;\n",e);
 			return;

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -8,6 +8,7 @@ const EngineExtensionManager = require("./extensionmanager.js");
 
 const path = require("path");
 const StorageManager = require("./store.js");
+const TokenManager = require("./tokenman.js");
 /**
  * @projectname diddle.js
  * @version 0.1.2
@@ -33,7 +34,8 @@ class DiddleEngine {
 			'diddle.js/eventman@0.1b',
 			'diddle.js/discord@0.1b',
 			'diddle.js/extman@0.1b',
-			'diddle.js/store@0.1'
+			'diddle.js/store@0.1',
+			'diddle.js/tokenman@0.1'
 		]
 	}
 
@@ -59,22 +61,23 @@ class DiddleEngine {
 			res(true);
 		})
 	}
-	/**
-	 * @type {LocaleManager}
-	 */
+	/** @type {LocaleManager} */
 	locale = null;
-	/**
-	 * @type {ConfigurationManager}
-	 */
+
+	/** @type {ConfigurationManager} */
 	config = null;
-	/**
-	 * @type {DiscordWrapper}
-	 */
+
+	/** @type {DiscordWrapper} */
 	discord = null;
-	/**
-	 * @type {ScriptManager}
-	 */
+
+	/** @type {ScriptManager} */
 	scripts = null;
+
+	/** @type {StorageManager} */
+	store = null;
+
+	/** @type {TokenManager} */
+	token = null;
 
 	/** @private */
 	_wrapperPopulate() {
@@ -85,8 +88,10 @@ class DiddleEngine {
 		this.scripts = new ScriptManager(diddle);
 		this.ext = new EngineExtensionManager(diddle);
 		this.store = new StorageManager(diddle);
+		this.token = new TokenManager(diddle);
 
 		this.config._ready();
+		this.token._ready();
 		this.store._ready();
 		this.ext._ready();
 		this.scripts._ready();

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -87,10 +87,10 @@ class DiddleEngine {
 		this.store = new StorageManager(diddle);
 
 		this.config._ready();
+		this.store._ready();
 		this.ext._ready();
 		this.scripts._ready();
 		this.discord._ready();
-		this.store._ready();
 	}
 	/**
 	 * @constructor

--- a/engine/extensionmanager.js
+++ b/engine/extensionmanager.js
@@ -61,7 +61,7 @@ class EngineExtensionManager extends EngineScript {
 	 * @returns {ExtensionScript[]}
 	 */
 	getByName(ScriptName) {
-		return this._score.filter(script => script.manifest.name == ScriptName);
+		return Object.entries(this._store).filter(script => script[1].manifest.name == ScriptName);
 	}
 
 	_fetchExtensions() {

--- a/engine/scriptman.js
+++ b/engine/scriptman.js
@@ -167,7 +167,7 @@ class ScriptManager extends EngineScript{
 			this._parseEventScript(c_script);
 		}
 
-		this.diddle.event.call('scripts-ready');
+		this.event.call('scripts-ready');
 	}
 
 	/**
@@ -182,9 +182,11 @@ class ScriptManager extends EngineScript{
 		for (let i = 0; i < scriptEvents.length; i++) {
 			let event = scriptEvents[i];
 			if (event[0] == 'ready') {
-				this.diddle.event.on('scripts-ready',event[1]);
+				this.event.on('scripts-ready',event[1]);
+			} else if (event[0].startsWith("discord")) {
+				this.diddle.discord.event.on(event[0],event[1]);
 			} else {
-				this.diddle.event.on(event[0],event[1]);
+				this.event.on(event[0],event[1]);
 			}
 		}
 	}

--- a/engine/store.js
+++ b/engine/store.js
@@ -153,7 +153,7 @@ class StorageManager extends EngineScript {
 	 * @returns {StorageObject[]}
 	 */
 	getByFilename(fname) {
-		return this._cache.filter(s => s.filename = fname);
+		return this._cache.filter(s => s.filename == fname);
 	}
 
 	create(_name) {

--- a/engine/tokenman.js
+++ b/engine/tokenman.js
@@ -1,0 +1,23 @@
+const EngineScript = require("./enginescript");
+
+const manifest = {
+	version: '0.1',
+	name: 'diddle.js/tokenman'
+}
+
+class TokenManager extends EngineScript {
+	constructor(diddle) {
+		super(diddle,manifest);
+		this.event.on('data-reload',() => {
+			this._data = this.diddle.config.get().token;
+		})
+	}
+	_ready() {
+		this.event.call('data-reload');
+	}
+
+	get(name) {
+		return this._data[name];
+	}
+}
+module.exports = TokenManager

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.1.3",
+	"version": "0.1.5",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {


### PR DESCRIPTION
# Requires Configuration Changes, see `engine/diddle.config.default.json` for new scheme!

Bug Fixes;
- [Engine] Set StorageManager Order to 2nd in method `_wrapperPopulate`
- [StorageManager] Fixed method `getByName`. Would set all storage object's filename to the one queried for.

Changes;
- Created `token` Object in default config
- [Discord] Moved Events to own scope instead of global
- [ScriptMan] Support for Discord Events being moved into own scope.
- Created TokenManager for the `token` object in configuration.