### PR TITLE
0.2.0 - New Extension/EngineScript Naming Method

### DIFF
--- a/engine/configman.js
+++ b/engine/configman.js
@@ -22,10 +22,10 @@ const manifest = {
  * @property {LocaleManager.LocaleCode} locale
  * @property {string} scripts_directory
  * @property {bool} debug
+ * @property {object} token Has children with the object name of the service and the content of either a string, or an array of strings.
  */
 /**
  * @typedef ConfigurationManager.discordconfig
- * @property {string} token Discord Bot Token, If It's a User Token discord.js will reject it
  * @property {string[]} admin Discord User ID Snowflakes
  * @property {string} prefix Command Prefix
  */

--- a/engine/configman.js
+++ b/engine/configman.js
@@ -12,7 +12,7 @@ function extend(target) {
 }
 const manifest = {
 	version: '0.1b',
-	name: 'diddle.js/configman'
+	name: 'org.js.diddle.engine.config'
 }
 
 /**
@@ -37,14 +37,13 @@ const manifest = {
  * @argument {ConfigurationManager.config} _config
  */
 class ConfigurationManager extends EngineScript{
-	async _ready() {
-		this.config = await extend({},DefaultConfig,this._config);
-
+	_ready() {
+		this.config = extend({},DefaultConfig,this._config);
 		this.locale = this.diddle.locale.switch(this.config.locale);
 	}
 	constructor(diddle,_config) {
 		super(diddle,manifest);
-		this.config = _config;
+		this._config = _config;
 		this.log.info(`Running ${this.manifest.name}@${this.manifest.version}`);
 	}
 

--- a/engine/diddle.config.default.json
+++ b/engine/diddle.config.default.json
@@ -1,9 +1,11 @@
 {
 	"disable": false,
 	"discord": {
-		"token": "",
 		"admin": [],
 		"prefix": "!"
+	},
+	"token": {
+		"discord": ""
 	},
 	"locale": "en_US",
 	"scripts": "./scripts/",

--- a/engine/discord.js
+++ b/engine/discord.js
@@ -21,8 +21,9 @@ class DiscordWrapper extends EngineScript{
 	 */
 	async _ready() {
 		this.log.info("connecting to discord");
+		var token = this.diddle.token.get("discord");
 		try {
-			await this.client.login(this.diddle.config.get().discord.token);
+			await this.client.login(token);
 		} catch(e) {
 			this.log.error("failed to connect to discord;\n",e);
 			return;

--- a/engine/discord.js
+++ b/engine/discord.js
@@ -3,8 +3,8 @@ const DiscordEvents = require("./discord-events.json");
 const EngineScript = require("./enginescript");
 
 const manifest = {
-	version: '0.1b',
-	name: 'diddle.js/discord'
+	version: '0.2',
+	name: 'org.js.diddle.engine.discord'
 }
 
 
@@ -20,8 +20,22 @@ class DiscordWrapper extends EngineScript{
 	 * @description Gets called when DiscordWrapper needs to be ready for other scripts to use.
 	 */
 	async _ready() {
+		this.cmd_prefix = this.diddle.pacman.get("org.js.diddle.engine.config").get().discord.prefix;
+		for ( let i = 0; i < DiscordEvents.length; i++ ) {
+			switch(DiscordEvents[i]) {
+				case "message":
+					this.client.on(DiscordEvents[i],(d) => {
+						var msg = this.msg(d);
+						this.event.call(`discord-${DiscordEvents[i]}`,msg)
+					});
+					break;
+				default:
+					this.client.on(DiscordEvents[i],d => this.event.call(`discord-${DiscordEvents[i]}`,d));
+					break;
+			}
+		}
 		this.log.info("connecting to discord");
-		var token = this.diddle.token.get("discord");
+		var token = this.diddle.pacman.get("org.js.diddle.engine.token").get("discord");
 		try {
 			await this.client.login(token);
 		} catch(e) {
@@ -37,7 +51,7 @@ class DiscordWrapper extends EngineScript{
 	 * @private
 	 */
 	msg(_message) {
-		_message.prefix = this.diddle.config.get().discord.prefix;
+		_message.prefix = this.diddle.pacman.get("org.js.diddle.engine.config").get().discord.prefix;
 		_message.command = _message.content.replace(_message.prefix,"").split(' ')[0];
 		_message.args = _message.content.split(_message.prefix+_message.command).join('').split(' ');
 		_message.command = _message.command.toLowerCase().trim();
@@ -48,21 +62,6 @@ class DiscordWrapper extends EngineScript{
 		super(diddle,manifest);
 		this.client = new discord.Client();
 		this.log.info(`Running ${this.manifest.name}@${this.manifest.version}`);
-		this.event = this.diddle.event;
-		this.cmd_prefix = this.diddle.config.get().discord.prefix;
-		for ( let i = 0; i < DiscordEvents.length; i++ ) {
-			switch(DiscordEvents[i]) {
-				case "message":
-					this.client.on(DiscordEvents[i],(d) => {
-						var msg = this.msg(d);
-						this.event.call(`discord-${DiscordEvents[i]}`,msg)
-					});
-					break;
-				default:
-					this.client.on(DiscordEvents[i],d => this.event.call(`discord-${DiscordEvents[i]}`,d));
-					break;
-			}
-		}
 	}
 	
 }

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -8,6 +8,7 @@ const EngineExtensionManager = require("./extensionmanager.js");
 
 const path = require("path");
 const StorageManager = require("./store.js");
+const TokenManager = require("./tokenman.js");
 /**
  * @projectname diddle.js
  * @version 0.1.2
@@ -33,7 +34,8 @@ class DiddleEngine {
 			'diddle.js/eventman@0.1b',
 			'diddle.js/discord@0.1b',
 			'diddle.js/extman@0.1b',
-			'diddle.js/store@0.1'
+			'diddle.js/store@0.1',
+			'diddle.js/tokenman@0.1'
 		]
 	}
 
@@ -59,22 +61,23 @@ class DiddleEngine {
 			res(true);
 		})
 	}
-	/**
-	 * @type {LocaleManager}
-	 */
+	/** @type {LocaleManager} */
 	locale = null;
-	/**
-	 * @type {ConfigurationManager}
-	 */
+
+	/** @type {ConfigurationManager} */
 	config = null;
-	/**
-	 * @type {DiscordWrapper}
-	 */
+
+	/** @type {DiscordWrapper} */
 	discord = null;
-	/**
-	 * @type {ScriptManager}
-	 */
+
+	/** @type {ScriptManager} */
 	scripts = null;
+
+	/** @type {StorageManager} */
+	store = null;
+
+	/** @type {TokenManager} */
+	token = null;
 
 	/** @private */
 	_wrapperPopulate() {
@@ -85,8 +88,10 @@ class DiddleEngine {
 		this.scripts = new ScriptManager(diddle);
 		this.ext = new EngineExtensionManager(diddle);
 		this.store = new StorageManager(diddle);
+		this.token = new TokenManager(diddle);
 
 		this.config._ready();
+		this.token._ready();
 		this.store._ready();
 		this.ext._ready();
 		this.scripts._ready();

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -87,10 +87,10 @@ class DiddleEngine {
 		this.store = new StorageManager(diddle);
 
 		this.config._ready();
+		this.store._ready();
 		this.ext._ready();
 		this.scripts._ready();
 		this.discord._ready();
-		this.store._ready();
 	}
 	/**
 	 * @constructor

--- a/engine/eventman.js
+++ b/engine/eventman.js
@@ -2,7 +2,7 @@ const Logger = require("./logger");
 
 const manifest = {
 	version: '0.1b',
-	name: 'diddle.js/eventman'
+	name: 'org.js.diddle.engine.event'
 }
 /**
  * @class EventManager
@@ -13,7 +13,7 @@ class EventManager {
 	constructor(diddle) {
 		this.diddle = diddle;
 		this._eventchannels = {}
-		this.log = new Logger(diddle,"diddle.js/eventman");
+		this.log = new Logger(diddle,manifest.name);
 		this.manifest = manifest;
 	}
 	/**

--- a/engine/extensionmanager.js
+++ b/engine/extensionmanager.js
@@ -4,8 +4,8 @@ const path = require("path")
 const fs = require("fs")
 
 const manifest = {
-	name: "diddle.js/extman",
-	version: "0.1b"
+	name: "org.js.diddle.engine.extension",
+	version: "0.1"
 }
 
 function isClass(v) {
@@ -65,7 +65,7 @@ class EngineExtensionManager extends EngineScript {
 	}
 
 	_fetchExtensions() {
-		var config = this.diddle.config.get();
+		var config = this.diddle.pacman.get("org.js.diddle.engine.config").get();
 
 		var timestamp_start = Date.now();
 
@@ -99,7 +99,8 @@ class EngineExtensionManager extends EngineScript {
 			let current = require(path.join(this.cwd,current_filename));
 
 			if (isClass(current)) {
-				var ext = new current(this.diddle)
+				var ext = new current(this.diddle);
+				if (ext.manifest.name)
 				ext_filtered.push(ext);
 				this.log.debug(`loaded extension ${ext.manifest.name}@${ext.manifest.version} (${ext._ScriptUID})`)
 			} else {
@@ -107,6 +108,8 @@ class EngineExtensionManager extends EngineScript {
 				return;
 			}
 		}
+
+		this.extensions = ext_filtered;
 
 		this.log.info(`took ${Date.now() - timestamp_start}ms`);
 	}

--- a/engine/extensionmanager.js
+++ b/engine/extensionmanager.js
@@ -61,7 +61,7 @@ class EngineExtensionManager extends EngineScript {
 	 * @returns {ExtensionScript[]}
 	 */
 	getByName(ScriptName) {
-		return this._score.filter(script => script.manifest.name == ScriptName);
+		return Object.entries(this._store).filter(script => script[1].manifest.name == ScriptName);
 	}
 
 	_fetchExtensions() {

--- a/engine/extensionscript.js
+++ b/engine/extensionscript.js
@@ -14,7 +14,7 @@ class ExtensionScript extends EngineScript {
 	constructor(diddle,manifest) {
 		super(diddle,manifest);
 		this._ScriptUID = crypto.createHash("md5").update(manifest.name + "@" + manifest.version).digest("hex");
-		this.diddle.ext.append(this);
+		this.diddle.pacman.get("org.js.diddle.engine.extension").append(this);
 	}
 
 }

--- a/engine/locale.js
+++ b/engine/locale.js
@@ -5,7 +5,7 @@ const EngineScript = require("./enginescript");
 
 const manifest = {
 	version: '0.1b',
-	name: 'diddle.js/locale'
+	name: 'org.js.diddle.engine.locale'
 }
 
 function extend(target) {

--- a/engine/logger.js
+++ b/engine/logger.js
@@ -6,7 +6,7 @@
 class Logger {
 	constructor(diddle,prefix) { 
 		this.diddle = diddle; 
-		this.prefix = prefix || "diddle.js";
+		this.prefix = prefix || "org.js.diddle";
 	}
 
 	color = {

--- a/engine/pacman.js
+++ b/engine/pacman.js
@@ -1,0 +1,48 @@
+const EngineScript = require("./enginescript");
+
+const manifest = {
+	name: "org.js.diddle.engine.pacman",
+	version: "0.1"
+}
+
+/**
+ * @extends {EngineScript}
+ */
+class PackageManager extends EngineScript {
+	_processPackageArray(arr) {
+		for (let i = 0; i < arr.length; i++) {
+			var currentscript = arr[i];
+			if (/^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/.test(currentscript.manifest.name) && !currentscript.manifest.name.startsWith("_processPackageArray")) {
+				/*let wstring = '';
+				var mname = currentscript.manifest.name.split(".");
+				for (let j = 0; j < mname.length; j++) {
+					var wname = mname[j]
+					wstring+="."+wname;
+
+					eval(`this${wstring} = this${wstring} || {};`);
+				}
+				eval("this."+currentscript.manifest.name+" = currentscript");*/
+				this._data[currentscript.manifest.name] = currentscript;
+				if (currentscript._ready != undefined) {
+					currentscript._ready();
+				}
+			}
+		}
+	}
+	/**
+	 * @param {string} PackageName Package name matching Java's package naming conventions
+	 * @returns {EngineScript|ExtensionScript|undefined}
+	 */
+	get(PackageName) {
+		return this._data[PackageName];
+	}
+	/**
+	 * 
+	 * @param {DiddleEngine} diddle 
+	 */
+	constructor(diddle) {
+		super(diddle,manifest);
+		this._data = {};
+	}
+}
+module.exports = PackageManager;

--- a/engine/scriptman.js
+++ b/engine/scriptman.js
@@ -167,7 +167,7 @@ class ScriptManager extends EngineScript{
 			this._parseEventScript(c_script);
 		}
 
-		this.diddle.event.call('scripts-ready');
+		this.event.call('scripts-ready');
 	}
 
 	/**
@@ -182,9 +182,11 @@ class ScriptManager extends EngineScript{
 		for (let i = 0; i < scriptEvents.length; i++) {
 			let event = scriptEvents[i];
 			if (event[0] == 'ready') {
-				this.diddle.event.on('scripts-ready',event[1]);
+				this.event.on('scripts-ready',event[1]);
+			} else if (event[0].startsWith("discord")) {
+				this.diddle.discord.event.on(event[0],event[1]);
 			} else {
-				this.diddle.event.on(event[0],event[1]);
+				this.event.on(event[0],event[1]);
 			}
 		}
 	}

--- a/engine/scriptman.js
+++ b/engine/scriptman.js
@@ -4,7 +4,7 @@ const EngineScript = require("./enginescript");
 
 const manifest = {
 	version: '0.1b',
-	name: 'diddle.js/scriptman'
+	name: 'org.js.diddle.engine.script'
 }
 /**
  * @class ScriptManager
@@ -17,7 +17,7 @@ class ScriptManager extends EngineScript{
 	 * Fetch All Valid scripts in the specifiyed directory in {DiddleEngine.config.cache}
 	 */
 	_fetchScripts() {
-		var config = this.diddle.config.get();
+		var config = this.diddle.pacman.get("org.js.diddle.engine.config").get();
 
 		var timestamp_start = Date.now();
 
@@ -145,6 +145,7 @@ class ScriptManager extends EngineScript{
 				}
 			} catch(e) {
 				this.log.error(`cannot get script\n`,e);
+				console.error(e);
 				process.exit(1);
 			}
 		}
@@ -184,7 +185,7 @@ class ScriptManager extends EngineScript{
 			if (event[0] == 'ready') {
 				this.event.on('scripts-ready',event[1]);
 			} else if (event[0].startsWith("discord")) {
-				this.diddle.discord.event.on(event[0],event[1]);
+				this.diddle.pacman.get("org.js.diddle.engine.discord").event.on(event[0],event[1]);
 			} else {
 				this.event.on(event[0],event[1]);
 			}

--- a/engine/store.js
+++ b/engine/store.js
@@ -153,7 +153,7 @@ class StorageManager extends EngineScript {
 	 * @returns {StorageObject[]}
 	 */
 	getByFilename(fname) {
-		return this._cache.filter(s => s.filename = fname);
+		return this._cache.filter(s => s.filename == fname);
 	}
 
 	create(_name) {

--- a/engine/store.js
+++ b/engine/store.js
@@ -4,7 +4,7 @@ const path = require("path")
 const toolbox = require("tinytoolbox")
 
 const manifest = {
-	name: 'diddle.js/store',
+	name: 'org.js.diddle.engine.store',
 	version: '0.1'
 };
 
@@ -17,8 +17,15 @@ const manifest = {
 class StorageObject {
 	hasUpdated = false;
 
+	_data = {
+		meta: {
+			name: '',
+			id: '',
+		},
+		content: null
+	}
+
 	/**
-	 * 
 	 * @param {string} _filename A Valid JSON Filename
 	 * @param {string} _directory A Valid Directory
 	 */
@@ -30,13 +37,11 @@ class StorageObject {
 		if (!fs.existsSync(_directory)) {
 			fs.mkdirSync(_directory,{recursive:true});
 		}
-
 		this.sync()
 		if (this._data.meta.id.length < 1) {
 			this.resetID();
 		}
 		this.sync()
-
 	}
 
 	/**
@@ -57,14 +62,6 @@ class StorageObject {
 			console.error(`\x1b[41m====== [FATAL STORAGE ERROR] ======\x1b[0m\n${this.location}\n`,error,`\n\x1b[41m====== ##################### ======\x1b[0m`)
 			return error;
 		}
-	}
-
-	_data = {
-		meta: {
-			name: '',
-			id: '',
-		},
-		content: null
 	}
 
 	/**
@@ -103,13 +100,13 @@ class StorageManager extends EngineScript {
 	}
 
 	_ready() {
-		this.directory = path.resolve(this.diddle.config.get().data);
+		this.directory = path.resolve(this.diddle.pacman.get("org.js.diddle.engine.config").get().data);
 
 		if (!fs.existsSync(this.directory)) {
 			try {
 				fs.mkdirSync(this.directory);
 			} catch (e) {
-				this.log.error(`failed to create data directory;\n${e.toString()}`);
+				this.log.error(`failed to create data directory;\n${e.stack}`);
 				process.exit(1);
 			}
 			this.log.debug(`created data directory`);
@@ -119,7 +116,12 @@ class StorageManager extends EngineScript {
 
 		for (let i = 0; i < files.length; i++) {
 			var fname = files[i];
-			this._cache.push(new StorageObject(fname,this.directory));
+			switch (fname.startsWith) {
+				case "js":
+				case "json":
+					this._cache.push(new StorageObject(fname,this.directory));
+					break;
+			}
 		}
 	}
 

--- a/engine/tokenman.js
+++ b/engine/tokenman.js
@@ -1,0 +1,23 @@
+const EngineScript = require("./enginescript");
+
+const manifest = {
+	version: '0.1',
+	name: 'diddle.js/tokenman'
+}
+
+class TokenManager extends EngineScript {
+	constructor(diddle) {
+		super(diddle,manifest);
+		this.event.on('data-reload',() => {
+			this._data = this.diddle.config.get().token;
+		})
+	}
+	_ready() {
+		this.event.call('data-reload');
+	}
+
+	get(name) {
+		return this._data[name];
+	}
+}
+module.exports = TokenManager

--- a/engine/tokenman.js
+++ b/engine/tokenman.js
@@ -2,14 +2,14 @@ const EngineScript = require("./enginescript");
 
 const manifest = {
 	version: '0.1',
-	name: 'diddle.js/tokenman'
+	name: 'org.js.diddle.engine.token'
 }
 
 class TokenManager extends EngineScript {
 	constructor(diddle) {
 		super(diddle,manifest);
 		this.event.on('data-reload',() => {
-			this._data = this.diddle.config.get().token;
+			this._data = this.diddle.pacman.get("org.js.diddle.engine.config").get().token;
 		})
 	}
 	_ready() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.1.3",
+	"version": "0.1.5",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {


### PR DESCRIPTION
Engine Scripts and User Extensions are required to match the same naming scheme as Java Packages, for example, the Script Name for `ConfigurationManager` would be `org.js.diddle.engine.config`.

If you were fetching the config with `this.diddle.config.get()` you must use `this.diddle.pacman.get("org.js.diddle.engine.config").get()` instead. 