### PR TITLE
[0.2.1] Event Using PromiseAll instead of AwaitForEach

### DIFF
--- a/engine/eventman.js
+++ b/engine/eventman.js
@@ -40,7 +40,16 @@ class EventManager {
 			this._eventchannels[_channel] = [];
 		}
 		this.log.debug(`called event '${_channel}' `,_data || '');
-		this._eventchannels[_channel].forEach(c => c(this.diddle,_data || null));
+		return new Promise(async (resolve,reject) => {
+			let channel = this._eventchannels[_channel];
+			for (let i = 0; i < channel.length; i++) {
+				let c = channel[i];
+				let response = await c(this.diddle,_data || null);
+				if (response != undefined && response.stack != undefined) {
+					reject(response);
+				}
+			}
+		})
 	}
 }
 module.exports = EventManager;

--- a/engine/eventman.js
+++ b/engine/eventman.js
@@ -41,14 +41,21 @@ class EventManager {
 		}
 		this.log.debug(`called event '${_channel}' `,_data || '');
 		return new Promise(async (resolve,reject) => {
-			let channel = this._eventchannels[_channel];
-			for (let i = 0; i < channel.length; i++) {
-				let c = channel[i];
-				let response = await c(this.diddle,_data || null);
-				if (response != undefined && response.stack != undefined) {
-					reject(response);
-				}
-			}
+			let tmpPromise = this._eventchannels[_channel].map(e => new Promise(res => e(this.diddle,_data || null)));
+
+			Promise.all(tmpPromise)
+				.then((response) =>
+				{
+					if (response != undefined && response.stack != undefined)
+					{
+						reject(response);
+					}
+					else
+					{
+						resolve(response == undefined ? null : response);
+					}
+				})
+				.catch(reject);
 		})
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "diddle.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {


### PR DESCRIPTION
In `engine/eventman.js` calling events used PromiseAll for the targeted channel instead of using Await in a for(each) statement, making execution of events much faster.