### PR TITLE
Fixed multiple arguments not working with event manager

### DIFF
--- a/engine/discord.js
+++ b/engine/discord.js
@@ -48,7 +48,13 @@ class DiscordWrapper extends EngineScript{
 					});
 					break;
 				default:
-					this.client.on(DiscordEvents[i],d => this.event.call(`discord-${DiscordEvents[i]}`,d));
+					this.client.on(DiscordEvents[i],(...d) => 
+					{
+						// Yes, It's jank but it works. :/
+						let args = [`discord-${DiscordEvents[i]}`];
+						args = args.concat(d);
+						this.event.call( ...args );
+					});
 					break;
 			}
 		}

--- a/engine/eventman.js
+++ b/engine/eventman.js
@@ -35,13 +35,13 @@ class EventManager {
 	 * @param {string} _channel 
 	 * @param {*} _data 
 	 */
-	call (_channel,_data) {
+	call (_channel,..._data) {
 		if (this._eventchannels[_channel] == undefined) {
 			this._eventchannels[_channel] = [];
 		}
 		this.log.debug(`called event '${_channel}' `,_data || '');
 		return new Promise(async (resolve,reject) => {
-			let tmpPromise = this._eventchannels[_channel].map(e => new Promise(res => e(this.diddle,_data || null)));
+			let tmpPromise = this._eventchannels[_channel].map(e => new Promise(res => e(this.diddle,..._data || null)));
 
 			Promise.all(tmpPromise)
 				.then((response) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "diddle.js",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Middleware for the Popular Discord API Wrapper 'Discord.JS'",
 	"main": "engine/engine.js",
 	"bin": {


### PR DESCRIPTION
If you use the event manager to call a channel with more than one data argument it would fail. For example, if you wanted to send objects; `foo` and `bar` only `foo` would be sent.